### PR TITLE
Improved support for Linux one-click launcher

### DIFF
--- a/oneclick/%{NAME}.sh.template
+++ b/oneclick/%{NAME}.sh.template
@@ -1,20 +1,32 @@
 #!/bin/sh
 
 # path
-ROOT=`dirname $0`
+ROOT=`readlink -f $(dirname $0)`
 LINUX="$ROOT/Contents/Linux"
 RESOURCES="$ROOT/Contents/Resources"
 
-# icon
+# icon (note: gvfs-set-attribute is found in gvfs-bin on Ubuntu
+# systems and it seems to require an absolute filename)
 gvfs-set-attribute \
 	"$0" \
 	"metadata::custom-icon" \
 	"file://$RESOURCES/Squeak.png" \
 		2> /dev/null
 
+# zenity is part of GNOME
+image_count=`ls "$RESOURCES"/*.image 2>/dev/null |wc -l`
+if which zenity &>/dev/null && [ "$image_count"  -ne 1 ]; then
+	olddir=`pwd`
+	cd "$RESOURCES"
+	image=`zenity --title 'Select an image' --file-selection --file-filter '*.image' --file-filter '*'`
+	cd "$olddir"
+else
+	image="$RESOURCES/%{NAME}.image"
+fi
+
 # execute
 exec "$LINUX/squeak" \
 	-plugins "$LINUX" \
 	-encoding latin1 \
 	-vm-display-X11 \
-	"$RESOURCES/%{NAME}.image"
+	"$image"


### PR DESCRIPTION
In my fork, I've added some changes to the shell script for starting Pharo on Linux.  Where before the launcher would _always_ start pharo.image, now it will provide an image file selection dialog when either 0, or more than 1 .image file is found in the Contents/Resources directory.  The file selection is achieved via Zenity which is included in GNOME.  If Zenity is not present, then the script proceeds with the old behavior i.e. pharo.image.

Also, I could not see the icon in GNOME's Nautilus unless I used the full path to PNG file with gvfs-set-attribute.
