### PR TITLE
Add Seaside-Pharo-JSON-Core

### DIFF
--- a/scripts/seaside31.st
+++ b/scripts/seaside31.st
@@ -71,6 +71,7 @@ Gofer new
 	squeaksource: 'Seaside31';
 	package: 'Javascript-Core';
 	package: 'Seaside-JSON-Core';
+	package: 'Seaside-Pharo-JSON-Core';
 	package: 'Javascript-Pharo-Core';
 	package: 'Javascript-Tests-Core';
 	package: 'Javascript-Tests-Pharo-Core';


### PR DESCRIPTION
As part of Issue 726 (Rework JSON and JavaScript escaping) there's now
an optimized version of Seaside-JSON-Core that uses the same CharSet
primitive tricks that we already use for XML and JSON that should give
us much better performance for the common use case (no escaping
required).

http://code.google.com/p/seaside/issues/detail?id=726
