### PR TITLE
Add JQuery-JSON

### DIFF
--- a/scripts/seaside31.st
+++ b/scripts/seaside31.st
@@ -78,6 +78,8 @@ Gofer new
 	package: 'Seaside-Tests-JSON';
 	package: 'JQuery-Core';
 	package: 'JQuery-Tests-Core';
+	package: 'JQuery-JSON';
+	package: 'JQuery-Tests-JSON';
 	package: 'JQuery-UI';
 	package: 'JQuery-Tests-UI';
 	package: 'Prototype-Core';


### PR DESCRIPTION
As part of Issue 726 (Rework JSON and JavaScript escaping) a new
package JQuery-JSON was created which holds the sole JQuery-Core method
that was dependent on JSON. This allows us to clean up our
dependencies.

Our dependencies now look like this:
- Javascript-Core does not depend on JSON
- JSON does not depend on Javascript-Core
- JQuery-Core only depends on Javascript-Core

http://code.google.com/p/seaside/issues/detail?id=726
