### PR TITLE
For pre-pharo-2.0 Zinc needs the package 'Zinc-FileSystem-Legacy'.

### DIFF
--- a/scripts/zinc.st
+++ b/scripts/zinc.st
@@ -2,6 +2,7 @@
 Gofer new
 	squeaksource: 'ZincHTTPComponents';
 	package: 'Zinc-HTTP';
+        package: 'Zinc-FileSystem-Legacy';
 	package: 'Zinc-Tests';
 	load.
 !


### PR DESCRIPTION
Hi Lukas,

For pre-pharo-2.0 Zinc needs the package 'Zinc-FileSystem-Legacy'.
This modification is all that is required.

Thx,

Sven
