### PR TITLE
Move to SmalltalkHub

### DIFF
--- a/scripts/seaside31-kom.st
+++ b/scripts/seaside31-kom.st
@@ -6,7 +6,7 @@ Gofer new
 !
 "Komanche Adaptors"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-Adaptors-Comanche';
 	package: 'Seaside-Tests-Adaptors-Comanche';
 	load.

--- a/scripts/seaside31-pharo2.st
+++ b/scripts/seaside31-pharo2.st
@@ -1,6 +1,6 @@
 "Basic"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Grease-Core';
 	package: 'Grease-Pharo20-Core';
 	package: 'Grease-Tests-Core';
@@ -28,7 +28,7 @@ Gofer new
 !
 "Traditional"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-Tests-Functional';
 	package: 'Seaside-Tests-Pharo-Functional';
 	package: 'Seaside-Pharo-Continuation';
@@ -49,7 +49,7 @@ Gofer new
 !
 "RSS"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'RSS-Core';
 	package: 'RSS-Tests-Core';
 	package: 'RSS-Examples';
@@ -57,7 +57,7 @@ Gofer new
 !
 "Javascript"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Javascript-Core';
 	package: 'Seaside-JSON-Core';
 	package: 'Seaside-Pharo-JSON-Core';
@@ -85,7 +85,7 @@ Gofer new
 !
 "Other Packages"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-Welcome';
 	package: 'Seaside-Pharo-Welcome';
 	package: 'Seaside-Tests-Welcome';
@@ -101,7 +101,7 @@ Gofer new
 !
 "REST"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-REST-Core';
 	package: 'Seaside-Pharo-REST-Core';
 	package: 'Seaside-Tests-REST-Core';

--- a/scripts/seaside31-swazoo.st
+++ b/scripts/seaside31-swazoo.st
@@ -10,12 +10,12 @@ Gofer new
 	load.
 !
 Gofer new
-	squeaksource: 'Seaside30LGPL';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside30LGPL/main';
 	package: 'Seaside-Swazoo';
 	load.
 !
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-Adaptors-Swazoo';
 	load.
 !

--- a/scripts/seaside31.st
+++ b/scripts/seaside31.st
@@ -1,6 +1,6 @@
 "Basic"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Grease-Core';
 	package: 'Grease-Pharo-Core';
 	package: 'Grease-Tests-Core';
@@ -28,7 +28,7 @@ Gofer new
 !
 "Traditional"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-Tests-Functional';
 	package: 'Seaside-Tests-Pharo-Functional';
 	package: 'Seaside-Pharo-Continuation';
@@ -49,7 +49,7 @@ Gofer new
 !
 "Development and Admin Tools"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Grease-Slime';
 	package: 'Grease-Tests-Slime';
 	package: 'Seaside-Slime';
@@ -60,7 +60,7 @@ Gofer new
 !
 "RSS"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'RSS-Core';
 	package: 'RSS-Tests-Core';
 	package: 'RSS-Examples';
@@ -68,7 +68,7 @@ Gofer new
 !
 "Javascript"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Javascript-Core';
 	package: 'Seaside-JSON-Core';
 	package: 'Seaside-Pharo-JSON-Core';
@@ -96,7 +96,7 @@ Gofer new
 !
 "Other Packages"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-Welcome';
 	package: 'Seaside-Pharo-Welcome';
 	package: 'Seaside-Tests-Welcome';
@@ -112,8 +112,9 @@ Gofer new
 !
 "REST"
 Gofer new
-	squeaksource: 'Seaside31';
+	url: 'http://smalltalkhub.com/mc/Seaside/Seaside31/main';
 	package: 'Seaside-REST-Core';
 	package: 'Seaside-Pharo-REST-Core';
 	package: 'Seaside-Tests-REST-Core';
 	load.
+


### PR DESCRIPTION
Now that Seaside in on SmalltalkHub update the build scripts to load Seaside
from SmalltalkHub.
