### PR TITLE
Remove HTML5 Packages from 3.1

### DIFF
--- a/scripts/seaside31.st
+++ b/scripts/seaside31.st
@@ -102,8 +102,6 @@ Gofer new
 	package: 'Seaside-Welcome';
 	package: 'Seaside-Pharo-Welcome';
 	package: 'Seaside-Tests-Welcome';
-	package: 'Seaside-HTML5';
-	package: 'Seaside-Tests-HTML5';
 	package: 'Seaside-InternetExplorer';
 	package: 'Seaside-Tests-InternetExplorer';
 	package: 'Seaside-Email';


### PR DESCRIPTION
In Seaside 3.1 the HTML5 support has been merged into the
HTML support.
